### PR TITLE
Fixed puppet-staging not downloading in puppet-deps.sh

### DIFF
--- a/puppet-deps.sh
+++ b/puppet-deps.sh
@@ -7,7 +7,7 @@ mkdir -p puppet/modules
 git clone git://github.com/puppetlabs/puppetlabs-stdlib.git puppet/modules/stdlib
 git clone https://github.com/puppetlabs/puppetlabs-apt puppet/modules/apt
 
-git clone git@github.com:nanliu/puppet-staging.git puppet/modules/staging
+git clone https://github.com/nanliu/puppet-staging.git puppet/modules/staging
 
 # consul
 git clone https://github.com/solarkennedy/puppet-consul puppet/modules/consul


### PR DESCRIPTION
Updated URL to puppet-staging because original URL did not clone when script ran
